### PR TITLE
 Provide hosts as environment settings and add npm run start script

### DIFF
--- a/config/settings.defaults.coffee
+++ b/config/settings.defaults.coffee
@@ -2,10 +2,10 @@ module.exports = Settings =
 	internal:
 		notifications:
 			port: 3042
-			host: "localhost"
+			host: process.env["LISTEN_ADDRESS"] or "localhost"
 
 	mongo:
-		url : 'mongodb://127.0.0.1/sharelatex'
+		url : "mongodb://#{process.env["MONGO_HOST"] or "localhost"}/sharelatex"
 
 	notifications:
 		healthCheck:

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -4,99 +4,113 @@
   "dependencies": {
     "async": {
       "version": "0.1.22",
-      "from": "async@>=0.1.22 <0.2.0",
+      "from": "https://registry.npmjs.org/async/-/async-0.1.22.tgz",
       "resolved": "https://registry.npmjs.org/async/-/async-0.1.22.tgz"
+    },
+    "coffee-script": {
+      "version": "1.7.1",
+      "from": "coffee-script@1.7.1",
+      "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.7.1.tgz",
+      "dependencies": {
+        "mkdirp": {
+          "version": "0.3.5",
+          "from": "mkdirp@>=0.3.5 <0.4.0",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz"
+        }
+      }
     },
     "express": {
       "version": "3.1.0",
-      "from": "express@3.1.0",
+      "from": "https://registry.npmjs.org/express/-/express-3.1.0.tgz",
       "resolved": "https://registry.npmjs.org/express/-/express-3.1.0.tgz",
       "dependencies": {
         "connect": {
           "version": "2.7.2",
-          "from": "connect@2.7.2",
+          "from": "https://registry.npmjs.org/connect/-/connect-2.7.2.tgz",
           "resolved": "https://registry.npmjs.org/connect/-/connect-2.7.2.tgz",
           "dependencies": {
             "qs": {
               "version": "0.5.1",
-              "from": "qs@0.5.1"
+              "from": "qs@0.5.1",
+              "resolved": "https://registry.npmjs.org/qs/-/qs-0.5.1.tgz"
             },
             "formidable": {
               "version": "1.0.11",
-              "from": "formidable@1.0.11",
+              "from": "https://registry.npmjs.org/formidable/-/formidable-1.0.11.tgz",
               "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.0.11.tgz"
             },
             "bytes": {
               "version": "0.1.0",
-              "from": "bytes@0.1.0",
+              "from": "https://registry.npmjs.org/bytes/-/bytes-0.1.0.tgz",
               "resolved": "https://registry.npmjs.org/bytes/-/bytes-0.1.0.tgz"
             },
             "pause": {
               "version": "0.0.1",
-              "from": "pause@0.0.1",
+              "from": "https://registry.npmjs.org/pause/-/pause-0.0.1.tgz",
               "resolved": "https://registry.npmjs.org/pause/-/pause-0.0.1.tgz"
             }
           }
         },
         "commander": {
           "version": "0.6.1",
-          "from": "commander@0.6.1",
+          "from": "https://registry.npmjs.org/commander/-/commander-0.6.1.tgz",
           "resolved": "https://registry.npmjs.org/commander/-/commander-0.6.1.tgz"
         },
         "range-parser": {
           "version": "0.0.4",
-          "from": "range-parser@0.0.4",
+          "from": "https://registry.npmjs.org/range-parser/-/range-parser-0.0.4.tgz",
           "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-0.0.4.tgz"
         },
         "mkdirp": {
           "version": "0.3.3",
-          "from": "mkdirp@0.3.3",
+          "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.3.tgz",
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.3.tgz"
         },
         "cookie": {
           "version": "0.0.5",
-          "from": "cookie@0.0.5",
+          "from": "https://registry.npmjs.org/cookie/-/cookie-0.0.5.tgz",
           "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.0.5.tgz"
         },
         "buffer-crc32": {
           "version": "0.1.1",
-          "from": "buffer-crc32@0.1.1",
+          "from": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.1.1.tgz",
           "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.1.1.tgz"
         },
         "fresh": {
           "version": "0.1.0",
-          "from": "fresh@0.1.0",
+          "from": "https://registry.npmjs.org/fresh/-/fresh-0.1.0.tgz",
           "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.1.0.tgz"
         },
         "methods": {
           "version": "0.0.1",
-          "from": "methods@0.0.1",
+          "from": "https://registry.npmjs.org/methods/-/methods-0.0.1.tgz",
           "resolved": "https://registry.npmjs.org/methods/-/methods-0.0.1.tgz"
         },
         "send": {
           "version": "0.1.0",
-          "from": "send@0.1.0",
+          "from": "https://registry.npmjs.org/send/-/send-0.1.0.tgz",
           "resolved": "https://registry.npmjs.org/send/-/send-0.1.0.tgz",
           "dependencies": {
             "mime": {
               "version": "1.2.6",
-              "from": "mime@1.2.6",
+              "from": "https://registry.npmjs.org/mime/-/mime-1.2.6.tgz",
               "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.6.tgz"
             }
           }
         },
         "cookie-signature": {
           "version": "0.0.1",
-          "from": "cookie-signature@0.0.1",
+          "from": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-0.0.1.tgz",
           "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-0.0.1.tgz"
         },
         "debug": {
           "version": "2.6.3",
-          "from": "debug@*",
+          "from": "debug@2.6.3",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.3.tgz",
           "dependencies": {
             "ms": {
               "version": "0.7.2",
-              "from": "ms@0.7.2",
+              "from": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
               "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz"
             }
           }
@@ -105,88 +119,93 @@
     },
     "logger-sharelatex": {
       "version": "1.0.0",
-      "from": "git+https://github.com/sharelatex/logger-sharelatex.git#v1.1.0",
+      "from": "git+https://github.com/sharelatex/logger-sharelatex.git#5a3ea8e655f23e76a77bbc207c012d3fc944c8d8",
       "resolved": "git+https://github.com/sharelatex/logger-sharelatex.git#5a3ea8e655f23e76a77bbc207c012d3fc944c8d8",
       "dependencies": {
         "bunyan": {
           "version": "1.3.6",
-          "from": "bunyan@1.3.6",
+          "from": "https://registry.npmjs.org/bunyan/-/bunyan-1.3.6.tgz",
           "resolved": "https://registry.npmjs.org/bunyan/-/bunyan-1.3.6.tgz",
           "dependencies": {
             "dtrace-provider": {
               "version": "0.4.0",
-              "from": "dtrace-provider@>=0.4.0 <0.5.0",
+              "from": "https://registry.npmjs.org/dtrace-provider/-/dtrace-provider-0.4.0.tgz",
               "resolved": "https://registry.npmjs.org/dtrace-provider/-/dtrace-provider-0.4.0.tgz",
               "dependencies": {
                 "nan": {
                   "version": "1.5.3",
-                  "from": "nan@>=1.5.1 <1.6.0",
+                  "from": "https://registry.npmjs.org/nan/-/nan-1.5.3.tgz",
                   "resolved": "https://registry.npmjs.org/nan/-/nan-1.5.3.tgz"
                 }
               }
             },
             "mv": {
               "version": "2.1.1",
-              "from": "mv@>=2.0.0 <3.0.0",
+              "from": "https://registry.npmjs.org/mv/-/mv-2.1.1.tgz",
               "resolved": "https://registry.npmjs.org/mv/-/mv-2.1.1.tgz",
               "dependencies": {
                 "mkdirp": {
                   "version": "0.5.1",
-                  "from": "mkdirp@>=0.5.1 <0.6.0",
+                  "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
                   "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
                   "dependencies": {
                     "minimist": {
                       "version": "0.0.8",
-                      "from": "minimist@0.0.8",
+                      "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
                       "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
                     }
                   }
                 },
                 "ncp": {
                   "version": "2.0.0",
-                  "from": "ncp@>=2.0.0 <2.1.0",
+                  "from": "https://registry.npmjs.org/ncp/-/ncp-2.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/ncp/-/ncp-2.0.0.tgz"
                 },
                 "rimraf": {
                   "version": "2.4.5",
-                  "from": "rimraf@>=2.4.0 <2.5.0",
+                  "from": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.5.tgz",
                   "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.5.tgz",
                   "dependencies": {
                     "glob": {
                       "version": "6.0.4",
-                      "from": "glob@>=6.0.1 <7.0.0",
+                      "from": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
                       "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
                       "dependencies": {
                         "inflight": {
                           "version": "1.0.6",
-                          "from": "inflight@>=1.0.4 <2.0.0",
+                          "from": "inflight@1.0.6",
+                          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
                           "dependencies": {
                             "wrappy": {
                               "version": "1.0.2",
-                              "from": "wrappy@>=1.0.0 <2.0.0",
+                              "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
                               "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
                             }
                           }
                         },
                         "inherits": {
                           "version": "2.0.3",
-                          "from": "inherits@>=2.0.0 <3.0.0"
+                          "from": "inherits@2.0.3",
+                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
                         },
                         "minimatch": {
                           "version": "3.0.3",
-                          "from": "minimatch@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0",
+                          "from": "minimatch@3.0.3",
+                          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
                           "dependencies": {
                             "brace-expansion": {
                               "version": "1.1.6",
-                              "from": "brace-expansion@>=1.0.0 <2.0.0",
+                              "from": "brace-expansion@1.1.6",
+                              "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
                               "dependencies": {
                                 "balanced-match": {
                                   "version": "0.4.2",
-                                  "from": "balanced-match@>=0.4.1 <0.5.0"
+                                  "from": "balanced-match@0.4.2",
+                                  "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz"
                                 },
                                 "concat-map": {
                                   "version": "0.0.1",
-                                  "from": "concat-map@0.0.1",
+                                  "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
                                   "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
                                 }
                               }
@@ -195,18 +214,20 @@
                         },
                         "once": {
                           "version": "1.4.0",
-                          "from": "once@>=1.3.0 <2.0.0",
+                          "from": "once@1.4.0",
+                          "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
                           "dependencies": {
                             "wrappy": {
                               "version": "1.0.2",
-                              "from": "wrappy@>=1.0.0 <2.0.0",
+                              "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
                               "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
                             }
                           }
                         },
                         "path-is-absolute": {
                           "version": "1.0.1",
-                          "from": "path-is-absolute@>=1.0.0 <2.0.0"
+                          "from": "path-is-absolute@1.0.1",
+                          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
                         }
                       }
                     }
@@ -216,36 +237,39 @@
             },
             "safe-json-stringify": {
               "version": "1.0.4",
-              "from": "safe-json-stringify@>=1.0.0 <2.0.0"
+              "from": "safe-json-stringify@1.0.4",
+              "resolved": "https://registry.npmjs.org/safe-json-stringify/-/safe-json-stringify-1.0.4.tgz"
             }
           }
         },
         "coffee-script": {
           "version": "1.4.0",
-          "from": "coffee-script@1.4.0"
+          "from": "coffee-script@1.4.0",
+          "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.4.0.tgz"
         },
         "raven": {
           "version": "0.8.1",
-          "from": "raven@>=0.8.0 <0.9.0",
+          "from": "https://registry.npmjs.org/raven/-/raven-0.8.1.tgz",
           "resolved": "https://registry.npmjs.org/raven/-/raven-0.8.1.tgz",
           "dependencies": {
             "cookie": {
               "version": "0.1.0",
-              "from": "cookie@0.1.0",
+              "from": "https://registry.npmjs.org/cookie/-/cookie-0.1.0.tgz",
               "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.1.0.tgz"
             },
             "lsmod": {
               "version": "0.0.3",
-              "from": "lsmod@>=0.0.3 <0.1.0",
+              "from": "https://registry.npmjs.org/lsmod/-/lsmod-0.0.3.tgz",
               "resolved": "https://registry.npmjs.org/lsmod/-/lsmod-0.0.3.tgz"
             },
             "node-uuid": {
               "version": "1.4.8",
-              "from": "node-uuid@>=1.4.1 <1.5.0"
+              "from": "node-uuid@1.4.8",
+              "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.8.tgz"
             },
             "stack-trace": {
               "version": "0.0.7",
-              "from": "stack-trace@0.0.7",
+              "from": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.7.tgz",
               "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.7.tgz"
             }
           }
@@ -254,76 +278,81 @@
     },
     "metrics-sharelatex": {
       "version": "1.7.1",
-      "from": "git+https://github.com/sharelatex/metrics-sharelatex.git#v1.7.1",
+      "from": "git+https://github.com/sharelatex/metrics-sharelatex.git#166961924c599b1f9468f2e17846fa2a9d12372d",
       "resolved": "git+https://github.com/sharelatex/metrics-sharelatex.git#166961924c599b1f9468f2e17846fa2a9d12372d",
       "dependencies": {
         "lynx": {
           "version": "0.1.1",
-          "from": "lynx@>=0.1.1 <0.2.0",
+          "from": "https://registry.npmjs.org/lynx/-/lynx-0.1.1.tgz",
           "resolved": "https://registry.npmjs.org/lynx/-/lynx-0.1.1.tgz",
           "dependencies": {
             "mersenne": {
               "version": "0.0.3",
-              "from": "mersenne@>=0.0.3 <0.1.0",
+              "from": "https://registry.npmjs.org/mersenne/-/mersenne-0.0.3.tgz",
               "resolved": "https://registry.npmjs.org/mersenne/-/mersenne-0.0.3.tgz"
             },
             "statsd-parser": {
               "version": "0.0.4",
-              "from": "statsd-parser@>=0.0.4 <0.1.0",
+              "from": "https://registry.npmjs.org/statsd-parser/-/statsd-parser-0.0.4.tgz",
               "resolved": "https://registry.npmjs.org/statsd-parser/-/statsd-parser-0.0.4.tgz"
             }
           }
         },
         "coffee-script": {
           "version": "1.6.0",
-          "from": "coffee-script@1.6.0"
+          "from": "coffee-script@1.6.0",
+          "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.6.0.tgz"
         },
         "underscore": {
           "version": "1.6.0",
-          "from": "underscore@>=1.6.0 <1.7.0",
+          "from": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
           "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz"
         }
       }
     },
     "mongojs": {
       "version": "2.4.0",
-      "from": "mongojs@>=2.4.0 <3.0.0",
+      "from": "https://registry.npmjs.org/mongojs/-/mongojs-2.4.0.tgz",
       "resolved": "https://registry.npmjs.org/mongojs/-/mongojs-2.4.0.tgz",
       "dependencies": {
         "each-series": {
           "version": "1.0.0",
-          "from": "each-series@>=1.0.0 <2.0.0",
+          "from": "https://registry.npmjs.org/each-series/-/each-series-1.0.0.tgz",
           "resolved": "https://registry.npmjs.org/each-series/-/each-series-1.0.0.tgz"
         },
         "mongodb": {
           "version": "2.2.25",
-          "from": "mongodb@>=2.0.45 <3.0.0",
+          "from": "mongodb@2.2.25",
+          "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-2.2.25.tgz",
           "dependencies": {
             "es6-promise": {
               "version": "3.2.1",
-              "from": "es6-promise@3.2.1",
+              "from": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.2.1.tgz",
               "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.2.1.tgz"
             },
             "mongodb-core": {
               "version": "2.1.9",
               "from": "mongodb-core@2.1.9",
+              "resolved": "https://registry.npmjs.org/mongodb-core/-/mongodb-core-2.1.9.tgz",
               "dependencies": {
                 "bson": {
                   "version": "1.0.4",
-                  "from": "bson@>=1.0.4 <1.1.0"
+                  "from": "bson@1.0.4",
+                  "resolved": "https://registry.npmjs.org/bson/-/bson-1.0.4.tgz"
                 },
                 "require_optional": {
                   "version": "1.0.0",
-                  "from": "require_optional@>=1.0.0 <1.1.0",
+                  "from": "https://registry.npmjs.org/require_optional/-/require_optional-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/require_optional/-/require_optional-1.0.0.tgz",
                   "dependencies": {
                     "semver": {
                       "version": "5.3.0",
-                      "from": "semver@>=5.1.0 <6.0.0"
+                      "from": "semver@5.3.0",
+                      "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz"
                     },
                     "resolve-from": {
                       "version": "2.0.0",
-                      "from": "resolve-from@>=2.0.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz"
                     }
                   }
@@ -333,38 +362,41 @@
             "readable-stream": {
               "version": "2.1.5",
               "from": "readable-stream@2.1.5",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
               "dependencies": {
                 "buffer-shims": {
                   "version": "1.0.0",
-                  "from": "buffer-shims@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz"
                 },
                 "core-util-is": {
                   "version": "1.0.2",
-                  "from": "core-util-is@>=1.0.0 <1.1.0",
+                  "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                 },
                 "inherits": {
                   "version": "2.0.3",
-                  "from": "inherits@>=2.0.1 <2.1.0"
+                  "from": "inherits@2.0.3",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
                 },
                 "isarray": {
                   "version": "1.0.0",
-                  "from": "isarray@>=1.0.0 <1.1.0",
+                  "from": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
                 },
                 "process-nextick-args": {
                   "version": "1.0.7",
-                  "from": "process-nextick-args@>=1.0.6 <1.1.0"
+                  "from": "process-nextick-args@1.0.7",
+                  "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
                 },
                 "string_decoder": {
                   "version": "0.10.31",
-                  "from": "string_decoder@>=0.10.0 <0.11.0",
+                  "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                   "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                 },
                 "util-deprecate": {
                   "version": "1.0.2",
-                  "from": "util-deprecate@>=1.0.1 <1.1.0",
+                  "from": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
                 }
               }
@@ -373,156 +405,170 @@
         },
         "once": {
           "version": "1.4.0",
-          "from": "once@>=1.3.2 <2.0.0",
+          "from": "once@1.4.0",
+          "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
           "dependencies": {
             "wrappy": {
               "version": "1.0.2",
-              "from": "wrappy@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
               "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
             }
           }
         },
         "parse-mongo-url": {
           "version": "1.1.1",
-          "from": "parse-mongo-url@>=1.1.0 <2.0.0",
+          "from": "https://registry.npmjs.org/parse-mongo-url/-/parse-mongo-url-1.1.1.tgz",
           "resolved": "https://registry.npmjs.org/parse-mongo-url/-/parse-mongo-url-1.1.1.tgz"
         },
         "readable-stream": {
           "version": "2.2.6",
-          "from": "readable-stream@>=2.0.2 <3.0.0",
+          "from": "readable-stream@2.2.6",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.6.tgz",
           "dependencies": {
             "buffer-shims": {
               "version": "1.0.0",
-              "from": "buffer-shims@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz"
             },
             "core-util-is": {
               "version": "1.0.2",
-              "from": "core-util-is@>=1.0.0 <1.1.0",
+              "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
               "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
             },
             "isarray": {
               "version": "1.0.0",
-              "from": "isarray@>=1.0.0 <1.1.0",
+              "from": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
             },
             "inherits": {
               "version": "2.0.3",
-              "from": "inherits@>=2.0.1 <2.1.0"
+              "from": "inherits@2.0.3",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
             },
             "process-nextick-args": {
               "version": "1.0.7",
-              "from": "process-nextick-args@>=1.0.6 <1.1.0"
+              "from": "process-nextick-args@1.0.7",
+              "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
             },
             "string_decoder": {
               "version": "0.10.31",
-              "from": "string_decoder@>=0.10.0 <0.11.0",
+              "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
               "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
             },
             "util-deprecate": {
               "version": "1.0.2",
-              "from": "util-deprecate@>=1.0.1 <1.1.0",
+              "from": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
               "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
             }
           }
         },
         "thunky": {
           "version": "0.1.0",
-          "from": "thunky@>=0.1.0 <0.2.0",
+          "from": "https://registry.npmjs.org/thunky/-/thunky-0.1.0.tgz",
           "resolved": "https://registry.npmjs.org/thunky/-/thunky-0.1.0.tgz"
         },
         "to-mongodb-core": {
           "version": "2.0.0",
-          "from": "to-mongodb-core@>=2.0.0 <3.0.0",
+          "from": "https://registry.npmjs.org/to-mongodb-core/-/to-mongodb-core-2.0.0.tgz",
           "resolved": "https://registry.npmjs.org/to-mongodb-core/-/to-mongodb-core-2.0.0.tgz"
         },
         "xtend": {
           "version": "4.0.1",
-          "from": "xtend@>=4.0.0 <5.0.0",
+          "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
           "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
         }
       }
     },
     "node-statsd": {
       "version": "0.0.3",
-      "from": "node-statsd@0.0.3",
+      "from": "https://registry.npmjs.org/node-statsd/-/node-statsd-0.0.3.tgz",
       "resolved": "https://registry.npmjs.org/node-statsd/-/node-statsd-0.0.3.tgz",
       "dependencies": {
         "mersenne": {
           "version": "0.0.3",
-          "from": "mersenne@*",
+          "from": "https://registry.npmjs.org/mersenne/-/mersenne-0.0.3.tgz",
           "resolved": "https://registry.npmjs.org/mersenne/-/mersenne-0.0.3.tgz"
         }
       }
     },
     "request": {
       "version": "2.81.0",
-      "from": "request@>=2.65.0 <3.0.0",
+      "from": "request@2.81.0",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
       "dependencies": {
         "aws-sign2": {
           "version": "0.6.0",
-          "from": "aws-sign2@>=0.6.0 <0.7.0",
+          "from": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
           "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz"
         },
         "aws4": {
           "version": "1.6.0",
-          "from": "aws4@>=1.2.1 <2.0.0"
+          "from": "aws4@1.6.0",
+          "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz"
         },
         "caseless": {
           "version": "0.12.0",
-          "from": "caseless@>=0.12.0 <0.13.0"
+          "from": "caseless@0.12.0",
+          "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz"
         },
         "combined-stream": {
           "version": "1.0.5",
-          "from": "combined-stream@>=1.0.5 <1.1.0",
+          "from": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
           "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
           "dependencies": {
             "delayed-stream": {
               "version": "1.0.0",
-              "from": "delayed-stream@>=1.0.0 <1.1.0",
+              "from": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
               "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
             }
           }
         },
         "extend": {
           "version": "3.0.0",
-          "from": "extend@>=3.0.0 <3.1.0",
+          "from": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz",
           "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz"
         },
         "forever-agent": {
           "version": "0.6.1",
-          "from": "forever-agent@>=0.6.1 <0.7.0",
+          "from": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
           "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
         },
         "form-data": {
           "version": "2.1.2",
-          "from": "form-data@>=2.1.1 <2.2.0",
+          "from": "form-data@2.1.2",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.2.tgz",
           "dependencies": {
             "asynckit": {
               "version": "0.4.0",
-              "from": "asynckit@>=0.4.0 <0.5.0"
+              "from": "asynckit@0.4.0",
+              "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz"
             }
           }
         },
         "har-validator": {
           "version": "4.2.1",
-          "from": "har-validator@>=4.2.1 <4.3.0",
+          "from": "har-validator@4.2.1",
+          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
           "dependencies": {
             "ajv": {
               "version": "4.11.5",
-              "from": "ajv@>=4.9.1 <5.0.0",
+              "from": "ajv@4.11.5",
+              "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.5.tgz",
               "dependencies": {
                 "co": {
                   "version": "4.6.0",
-                  "from": "co@>=4.6.0 <5.0.0"
+                  "from": "co@4.6.0",
+                  "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz"
                 },
                 "json-stable-stringify": {
                   "version": "1.0.1",
-                  "from": "json-stable-stringify@>=1.0.1 <2.0.0",
+                  "from": "json-stable-stringify@1.0.1",
+                  "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
                   "dependencies": {
                     "jsonify": {
                       "version": "0.0.0",
-                      "from": "jsonify@>=0.0.0 <0.1.0"
+                      "from": "jsonify@0.0.0",
+                      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz"
                     }
                   }
                 }
@@ -530,117 +576,124 @@
             },
             "har-schema": {
               "version": "1.0.5",
-              "from": "har-schema@>=1.0.5 <2.0.0"
+              "from": "har-schema@1.0.5",
+              "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz"
             }
           }
         },
         "hawk": {
           "version": "3.1.3",
-          "from": "hawk@>=3.1.3 <3.2.0",
+          "from": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
           "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
           "dependencies": {
             "hoek": {
               "version": "2.16.3",
-              "from": "hoek@>=2.0.0 <3.0.0",
+              "from": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
               "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
             },
             "boom": {
               "version": "2.10.1",
-              "from": "boom@>=2.0.0 <3.0.0",
+              "from": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
               "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
             },
             "cryptiles": {
               "version": "2.0.5",
-              "from": "cryptiles@>=2.0.0 <3.0.0",
+              "from": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
               "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
             },
             "sntp": {
               "version": "1.0.9",
-              "from": "sntp@>=1.0.0 <2.0.0",
+              "from": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
               "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
             }
           }
         },
         "http-signature": {
           "version": "1.1.1",
-          "from": "http-signature@>=1.1.0 <1.2.0",
+          "from": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
           "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
           "dependencies": {
             "assert-plus": {
               "version": "0.2.0",
-              "from": "assert-plus@>=0.2.0 <0.3.0",
+              "from": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
               "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz"
             },
             "jsprim": {
               "version": "1.4.0",
-              "from": "jsprim@>=1.2.2 <2.0.0",
+              "from": "jsprim@1.4.0",
+              "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.0.tgz",
               "dependencies": {
                 "assert-plus": {
                   "version": "1.0.0",
-                  "from": "assert-plus@1.0.0",
+                  "from": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
                 },
                 "extsprintf": {
                   "version": "1.0.2",
-                  "from": "extsprintf@1.0.2",
+                  "from": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz"
                 },
                 "json-schema": {
                   "version": "0.2.3",
-                  "from": "json-schema@0.2.3",
+                  "from": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
                   "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz"
                 },
                 "verror": {
                   "version": "1.3.6",
-                  "from": "verror@1.3.6",
+                  "from": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
                   "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz"
                 }
               }
             },
             "sshpk": {
               "version": "1.11.0",
-              "from": "sshpk@>=1.7.0 <2.0.0",
+              "from": "sshpk@1.11.0",
+              "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.11.0.tgz",
               "dependencies": {
                 "asn1": {
                   "version": "0.2.3",
-                  "from": "asn1@>=0.2.3 <0.3.0",
+                  "from": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
                   "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz"
                 },
                 "assert-plus": {
                   "version": "1.0.0",
-                  "from": "assert-plus@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
                 },
                 "dashdash": {
                   "version": "1.14.1",
-                  "from": "dashdash@>=1.12.0 <2.0.0"
+                  "from": "dashdash@1.14.1",
+                  "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz"
                 },
                 "getpass": {
                   "version": "0.1.6",
-                  "from": "getpass@>=0.1.1 <0.2.0",
+                  "from": "https://registry.npmjs.org/getpass/-/getpass-0.1.6.tgz",
                   "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.6.tgz"
                 },
                 "jsbn": {
                   "version": "0.1.1",
-                  "from": "jsbn@>=0.1.0 <0.2.0"
+                  "from": "jsbn@0.1.1",
+                  "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz"
                 },
                 "tweetnacl": {
                   "version": "0.14.5",
-                  "from": "tweetnacl@>=0.14.0 <0.15.0"
+                  "from": "tweetnacl@0.14.5",
+                  "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz"
                 },
                 "jodid25519": {
                   "version": "1.0.2",
-                  "from": "jodid25519@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz"
                 },
                 "ecc-jsbn": {
                   "version": "0.1.1",
-                  "from": "ecc-jsbn@>=0.1.1 <0.2.0",
+                  "from": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
                   "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz"
                 },
                 "bcrypt-pbkdf": {
                   "version": "1.0.1",
-                  "from": "bcrypt-pbkdf@>=1.0.0 <2.0.0"
+                  "from": "bcrypt-pbkdf@1.0.1",
+                  "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz"
                 }
               }
             }
@@ -648,85 +701,95 @@
         },
         "is-typedarray": {
           "version": "1.0.0",
-          "from": "is-typedarray@>=1.0.0 <1.1.0",
+          "from": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
           "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz"
         },
         "isstream": {
           "version": "0.1.2",
-          "from": "isstream@>=0.1.2 <0.2.0",
+          "from": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
           "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
         },
         "json-stringify-safe": {
           "version": "5.0.1",
-          "from": "json-stringify-safe@>=5.0.1 <5.1.0",
+          "from": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
           "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
         },
         "mime-types": {
           "version": "2.1.14",
-          "from": "mime-types@>=2.1.7 <2.2.0",
+          "from": "mime-types@2.1.14",
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.14.tgz",
           "dependencies": {
             "mime-db": {
               "version": "1.26.0",
-              "from": "mime-db@>=1.26.0 <1.27.0"
+              "from": "mime-db@1.26.0",
+              "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.26.0.tgz"
             }
           }
         },
         "oauth-sign": {
           "version": "0.8.2",
-          "from": "oauth-sign@>=0.8.1 <0.9.0"
+          "from": "oauth-sign@0.8.2",
+          "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz"
         },
         "performance-now": {
           "version": "0.2.0",
-          "from": "performance-now@>=0.2.0 <0.3.0"
+          "from": "performance-now@0.2.0",
+          "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz"
         },
         "qs": {
           "version": "6.4.0",
-          "from": "qs@>=6.4.0 <6.5.0"
+          "from": "qs@6.4.0",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz"
         },
         "safe-buffer": {
           "version": "5.0.1",
-          "from": "safe-buffer@>=5.0.1 <6.0.0"
+          "from": "safe-buffer@5.0.1",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz"
         },
         "stringstream": {
           "version": "0.0.5",
-          "from": "stringstream@>=0.0.4 <0.1.0",
+          "from": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
           "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz"
         },
         "tough-cookie": {
           "version": "2.3.2",
-          "from": "tough-cookie@>=2.3.0 <2.4.0",
+          "from": "tough-cookie@2.3.2",
+          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
           "dependencies": {
             "punycode": {
               "version": "1.4.1",
-              "from": "punycode@>=1.4.1 <2.0.0",
+              "from": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
               "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz"
             }
           }
         },
         "tunnel-agent": {
           "version": "0.6.0",
-          "from": "tunnel-agent@>=0.6.0 <0.7.0"
+          "from": "tunnel-agent@0.6.0",
+          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz"
         },
         "uuid": {
           "version": "3.0.1",
-          "from": "uuid@>=3.0.0 <4.0.0"
+          "from": "uuid@3.0.1",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz"
         }
       }
     },
     "settings-sharelatex": {
       "version": "1.0.0",
-      "from": "git+https://github.com/sharelatex/settings-sharelatex.git#v1.0.0",
+      "from": "git+https://github.com/sharelatex/settings-sharelatex.git#cbc5e41c1dbe6789721a14b3fdae05bf22546559",
       "resolved": "git+https://github.com/sharelatex/settings-sharelatex.git#cbc5e41c1dbe6789721a14b3fdae05bf22546559",
       "dependencies": {
         "coffee-script": {
           "version": "1.6.0",
-          "from": "coffee-script@1.6.0"
+          "from": "coffee-script@1.6.0",
+          "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.6.0.tgz"
         }
       }
     },
     "underscore": {
       "version": "1.4.4",
-      "from": "underscore@1.4.4",
+      "from": "https://registry.npmjs.org/underscore/-/underscore-1.4.4.tgz",
       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.4.4.tgz"
     }
   }

--- a/package.json
+++ b/package.json
@@ -4,12 +4,14 @@
   "description": "An API to handle user notifications",
   "main": "app.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "compile:app": "coffee -o app/js -c app/coffee && coffee -c app.coffee",
+    "start": "npm run compile:app && node app.js"
   },
   "author": "",
   "license": "ISC",
   "dependencies": {
     "async": "^0.1.22",
+    "coffee-script": "^1.7.1",
     "express": "3.1.0",
     "logger-sharelatex": "git+https://github.com/sharelatex/logger-sharelatex.git#v1.1.0",
     "metrics-sharelatex": "git+https://github.com/sharelatex/metrics-sharelatex.git#v1.7.1",


### PR DESCRIPTION
Makes this service compatible with https://github.com/sharelatex/sharelatex-dev-environment

Allows other service's locations to be passed in via environment variables which are provided by docker-compose.

Also provides an `npm run start` script as a common entry point to all services via docker-compose.