### PR TITLE
Add endpoint to remove notifications based on university_id

### DIFF
--- a/app.coffee
+++ b/app.coffee
@@ -26,6 +26,7 @@ app.post '/user/:user_id', controller.addNotification
 app.get '/user/:user_id', controller.getUserNotifications
 app.del '/user/:user_id/notification/:notification_id', controller.removeNotificationId
 app.del '/user/:user_id', controller.removeNotificationKey
+app.del '/user/:user_id/ip_matcher/:university_id', controller.removeNotificationIpMatcher
 app.del '/key/:key', controller.removeNotificationByKeyOnly
 
 app.get '/status', (req, res)->

--- a/app/coffee/Notifications.coffee
+++ b/app/coffee/Notifications.coffee
@@ -81,6 +81,13 @@ module.exports = Notifications =
 			key: notification_key
 		db.notifications.remove searchOps, {justOne: true}, callback
 
+	removeNotificationIpMatcher: (user_id, university_id, callback)->
+		searchOps =
+			user_id: ObjectId(user_id)
+			"messageOpts.university_id": parseInt(university_id)
+		updateOperation =
+			"$unset": {templateKey:true, messageOpts: true}
+		db.notifications.update searchOps, updateOperation, callback
 
 [
 	'getUserNotifications',

--- a/app/coffee/NotificationsController.coffee
+++ b/app/coffee/NotificationsController.coffee
@@ -31,6 +31,13 @@ module.exports =
 		Notifications.removeNotificationKey req.params.user_id, req.body.key, (err, notifications)->
 			res.send()
 
+  # custom mark as read to search by university_id message opt
+	removeNotificationIpMatcher: (req, res)->
+		logger.log user_id: req.params.user_id, query: req.params.university_id, "mark notification as read by university id"
+		metrics.inc "removeNotificationKey"
+		Notifications.removeNotificationIpMatcher req.params.user_id, req.params.university_id, (err, notifications)->
+			res.send()
+
 	removeNotificationByKeyOnly: (req, res)->
 		notification_key = req.params.key
 		logger.log {notification_key}, "mark notification as read by key only"

--- a/test/unit/coffee/NotificationsControllerTest.coffee
+++ b/test/unit/coffee/NotificationsControllerTest.coffee
@@ -74,3 +74,14 @@ describe 'Notifications Controller', ->
 			@controller.removeNotificationByKeyOnly req, send:(result)=>
 				@notifications.removeNotificationByKeyOnly.calledWith(notification_key).should.equal true
 				done()
+
+	describe "removeNotificationIpMatcher", ->
+		it "should tell the notifications to mark the notification as read by university id", (done)->
+			@notifications.removeNotificationIpMatcher = sinon.stub().callsArgWith(2)
+			req =
+				params:
+					user_id: user_id
+					university_id: 10
+			@controller.removeNotificationIpMatcher req, send:(result)=>
+				@notifications.removeNotificationIpMatcher.calledWith(user_id, 10).should.equal true
+				done()

--- a/test/unit/coffee/NotificationsTests.coffee
+++ b/test/unit/coffee/NotificationsTests.coffee
@@ -200,3 +200,18 @@ describe 'Notifications Tests', ->
 				assert.deepEqual(@removeStub.args[0][0], searchOps)
 				assert.deepEqual(@removeStub.args[0][1], opts)
 				done()
+
+	describe 'removeNotificationIpMatcher', ->
+		it 'should mark the notification key as read', (done)->
+			@updateStub.callsArgWith(2, null)
+			university_id = 10
+
+			@notifications.removeNotificationIpMatcher user_id, university_id, (err)=>
+				searchOps =
+					user_id: ObjectId(user_id)
+					'messageOpts.university_id': university_id
+				updateOperation =
+					"$unset": {templateKey:true, messageOpts: true}
+				assert.deepEqual(@updateStub.args[0][0], searchOps)
+				assert.deepEqual(@updateStub.args[0][1], updateOperation)
+				done()


### PR DESCRIPTION
<!-- Please review https://github.com/overleaf/write_latex/blob/master/.github/CONTRIBUTING.md for guidance on what is expected in each section. -->

### Description
For https://github.com/overleaf/sharelatex/issues/1558 we need to find notifications by university ids and user pairs. This just adds a custom delete endpoint, handler and tests for that
