### PR TITLE
[misc] drop unused node-statsd package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4605,11 +4605,6 @@
         }
       }
     },
-    "node-statsd": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/node-statsd/-/node-statsd-0.1.1.tgz",
-      "integrity": "sha1-J6WTSHY9CvegN6wqAx/vPwUQE9M="
-    },
     "nopt": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.3.tgz",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "logger-sharelatex": "^2.2.0",
     "method-override": "^3.0.0",
     "mongodb": "^3.6.0",
-    "node-statsd": "0.1.1",
     "request": "^2.88.2",
     "settings-sharelatex": "^1.1.0",
     "underscore": "1.9.2"


### PR DESCRIPTION
### Description

The metrics module does not support statsd anymore. Drop the now unused node-statsd package.

#### Related Issues / PRs

papercut 31

#### Potential Impact

Low.

#### Manual Testing Performed

- load the project dashboard then check logs of notifications service, see a 200 for `/user/YOUR_USER_ID`
